### PR TITLE
Incomplete multi-character sanitization fix

### DIFF
--- a/nyaa/static/js/bootstrap-select.js
+++ b/nyaa/static/js/bootstrap-select.js
@@ -804,8 +804,10 @@
         title = typeof this.options.title !== 'undefined' ? this.options.title : this.options.noneSelectedText;
       }
 
-      //strip all HTML tags and trim the result, then unescape any escaped tags
-      this.$button.attr('title', htmlUnescape($.trim(title.replace(/<[^>]*>?/g, ''))));
+      //strip all HTML tags in a DOM-safe way and trim the result, then unescape any escaped tags
+      var $tmp = $('<div>').html(title);
+      var plainTitle = $tmp.text();
+      this.$button.attr('title', htmlUnescape($.trim(plainTitle)));
       this.$button.children('.filter-option').html(title);
 
       this.$element.trigger('rendered.bs.select');


### PR DESCRIPTION
Fix for [https://github.com/sb745/NyaaV3/security/code-scanning/12](https://github.com/sb745/NyaaV3/security/code-scanning/12)

In general, to fix incomplete multi‑character sanitization you either (a) use a robust, well‑tested HTML sanitizer, or (b) avoid multi‑character patterns that can re‑introduce unsafe substrings after replacement, e.g., by repeatedly applying the replacement or by simplifying the pattern to per‑character matching.

Here, the code is only trying to produce a plain‑text `title` attribute from a potentially HTML‑formatted `title` value. The simplest robust change, without altering existing behavior, is to replace the current “strip all HTML tags” regex with a more reliable text extraction using the browser’s DOM: create a temporary element, set its `.html()` to the (untrusted) string, then use `.text()` to get the safe text. This uses jQuery’s own HTML parsing and text extraction instead of a brittle regex. We then keep the existing `htmlUnescape` and `$.trim` behavior around that text.

Concretely, in `render` at line 808 we will replace:

```js
this.$button.attr('title', htmlUnescape($.trim(title.replace(/<[^>]*>?/g, ''))));
```

with code that:

1. Creates a temporary `<div>` via jQuery.
2. Sets its HTML to `title`.
3. Reads `.text()` to strip all tags correctly.
4. Applies `$.trim` and `htmlUnescape` as before.
5. Sets the `title` attribute to that sanitized string.

All required jQuery functionality is already available in this file; no new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
